### PR TITLE
Running Average Improvements

### DIFF
--- a/BakingLab/AppSettings.cpp
+++ b/BakingLab/AppSettings.cpp
@@ -495,7 +495,7 @@ namespace AppSettings
         BakeMode.Initialize(tweakBar, "BakeMode", "Baking", "Bake Mode", "", BakeModes::SG9, 10, BakeModesLabels);
         Settings.AddSetting(&BakeMode);
 
-        SolveMode.Initialize(tweakBar, "SolveMode", "Baking", "Solve Mode", "", SolveModes::NNLS, 5, SolveModesLabels);
+        SolveMode.Initialize(tweakBar, "SolveMode", "Baking", "Solve Mode", "", SolveModes::RunningAverageNN, 5, SolveModesLabels);
         Settings.AddSetting(&SolveMode);
 
         CurrentScene.Initialize(tweakBar, "CurrentScene", "Scene", "Current Scene", "", Scenes::Box, 3, ScenesLabels);

--- a/BakingLab/MeshBaker.h
+++ b/BakingLab/MeshBaker.h
@@ -98,7 +98,7 @@ public:
     uint64 currNumTiles = 0;
 
     // Read/Write data shared with bake threads
-    FixedArray<Half4> bakeResults[AppSettings::MaxBasisCount];
+    FixedArray<Float4> bakeResults[AppSettings::MaxBasisCount];
     volatile int64 currBakeBatch = 0;
 
     // Read-only data shared with bake threads

--- a/BakingLab/SG.cpp
+++ b/BakingLab/SG.cpp
@@ -260,8 +260,8 @@ void SGRunningAverage(const Float3& dir, const Float3& color, SG* outSGs, uint64
 
 		lobeWeights[lobeIdx] += (sphericalIntegralGuess - lobeWeights[lobeIdx]) * sampleWeightScale;
 
-		// Clamp the spherical integral estimate to within a reasonable factor of the true value.
-		float sphericalIntegral = std::max(lobeWeights[lobeIdx], outSGs[lobeIdx].BasisSqIntegralOverDomain * 0.75f);
+		// Clamp the spherical integral estimate to at least the true value to reduce variance.
+		float sphericalIntegral = std::max(lobeWeights[lobeIdx], outSGs[lobeIdx].BasisSqIntegralOverDomain);
 
 		Float3 otherLobesContribution = currentEstimate - outSGs[lobeIdx].Amplitude * weight;
 		Float3 newValue = (color - otherLobesContribution) * (weight / sphericalIntegral);

--- a/BakingLab/SG.cpp
+++ b/BakingLab/SG.cpp
@@ -283,7 +283,7 @@ static void SolveRunningAverage(SGSolveParam& params, bool nonNegative)
 
     // Project color samples onto the SGs
     for(uint32 i = 0; i < params.NumSamples; ++i)
-        SGRunningAverage(params.XSamples[i], params.YSamples[i], params.OutSGs, params.NumSGs, (float)(i + 1), lobeWeights, nonNegative);
+        SGRunningAverage(params.XSamples[i], params.YSamples[i], params.OutSGs, params.NumSGs, (float)i, lobeWeights, nonNegative);
 }
 
 // Solve the set of spherical gaussians based on input set of data

--- a/BakingLab/SG.cpp
+++ b/BakingLab/SG.cpp
@@ -65,7 +65,7 @@ static void GenerateUniformHemisphereSGs(SG* sgs, uint64 numSGs)
         sgs[i].Sharpness = sharpness;
 
 	
-	const uint64 sampleCount = 1024;
+	const uint64 sampleCount = 2048;
 	Float2 samples[sampleCount];
 	GenerateHammersleySamples2D(samples, sampleCount);
 
@@ -76,15 +76,12 @@ static void GenerateUniformHemisphereSGs(SG* sgs, uint64 numSGs)
 	{
 		Float3 dir = SampleDirectionHemisphere(samples[i].x, samples[i].y);
 
-		for (uint32 i = 0; i < numSGs; ++i) 
+		for (uint32 j = 0; j < numSGs; ++j)
 		{
-			float weight = std::exp(sgs[i].Sharpness * (Float3::Dot(dir, sgs[i].Axis) - 1.0f));
-			sgs[i].BasisSqIntegralOverDomain += weight * weight;
+			float weight = std::exp(sgs[j].Sharpness * (Float3::Dot(dir, sgs[j].Axis) - 1.0f));
+			sgs[j].BasisSqIntegralOverDomain += (weight * weight - sgs[j].BasisSqIntegralOverDomain) / float(i + 1);
 		}
 	}
-
-	for (uint32 i = 0; i < numSGs; ++i)
-		sgs[i].BasisSqIntegralOverDomain /= (float)sampleCount;
 }
 
 void InitializeSGSolver(uint64 numSGs)


### PR DESCRIPTION
Improve the implementation of the running average algorithm within The Baking Lab. The quality is now almost identical to least squares

- Switch to NN Running Average as the default algorithm at launch (I hope this isn't too presumptuous! The results are imperceptibly different and the visualisation is much better).

- Use a Float4 intermediate rather than Half4. Previously, large sample counts actually increased the error – only large adjustments to the lobes were being recorded, which significantly increased the noise and caused red hotspots from high-intensity sun samples.

- Use more samples to calculate the basis integral squared over the hemisphere.

- Clamp to at least the precomputed integral rather than 0.75x it – doing so produces more accurate results.
