### PR TITLE
Add support for Enlighten's directional lightmaps.

### DIFF
--- a/BakingLab/AppSettings.cpp
+++ b/BakingLab/AppSettings.cpp
@@ -161,9 +161,10 @@ static const char* SampleModesLabels[5] =
     "CMJ",
 };
 
-static const char* BakeModesLabels[10] =
+static const char* BakeModesLabels[11] =
 {
     "Diffuse",
+    "Directional",
     "Half-Life 2",
     "L1 SH",
     "L2 SH",
@@ -525,7 +526,7 @@ namespace AppSettings
         BakeRussianRouletteProbability.Initialize(tweakBar, "BakeRussianRouletteProbability", "Baking", "Russian Roullette Probability", "Maximum probability for continuing when Russian roulette is used", 0.5000f, 0.0000f, 1.0000f, 0.0100f, ConversionMode::None, 1.0000f);
         Settings.AddSetting(&BakeRussianRouletteProbability);
 
-        BakeMode.Initialize(tweakBar, "BakeMode", "Baking", "Bake Mode", "The current encoding/basis used for baking light map sample points", BakeModes::SG5, 10, BakeModesLabels);
+        BakeMode.Initialize(tweakBar, "BakeMode", "Baking", "Bake Mode", "The current encoding/basis used for baking light map sample points", BakeModes::SG5, 11, BakeModesLabels);
         Settings.AddSetting(&BakeMode);
 
         SolveMode.Initialize(tweakBar, "SolveMode", "Baking", "Solve Mode", "Controls how path tracer radiance samples are converted into a set of per-texel SG lobes", SolveModes::RunningAverageNN, 5, SolveModesLabels);

--- a/BakingLab/AppSettings.cs
+++ b/BakingLab/AppSettings.cs
@@ -258,6 +258,9 @@ enum BakeModes
 {
     Diffuse = 0,
 
+    [EnumLabel("Directional")]
+    Directional,
+
     [EnumLabel("Half-Life 2")]
     HL2,
 

--- a/BakingLab/AppSettings.h
+++ b/BakingLab/AppSettings.h
@@ -230,15 +230,16 @@ typedef EnumSettingT<SampleModes> SampleModesSetting;
 enum class BakeModes
 {
     Diffuse = 0,
-    HL2 = 1,
-    SH4 = 2,
-    SH9 = 3,
-    H4 = 4,
-    H6 = 5,
-    SG5 = 6,
-    SG6 = 7,
-    SG9 = 8,
-    SG12 = 9,
+    Directional = 1,
+    HL2 = 2,
+    SH4 = 3,
+    SH9 = 4,
+    H4 = 5,
+    H6 = 6,
+    SG5 = 7,
+    SG6 = 8,
+    SG9 = 9,
+    SG12 = 10,
 
     NumValues
 };
@@ -595,7 +596,7 @@ namespace AppSettings
     inline uint64 BasisCount(uint64 bakeMode)
     {
         Assert_(bakeMode < uint64(BakeModes::NumValues));
-        static const uint64 BasisCounts[] = { 1, 3, 4, 9, 4, 6, 5, 6, 9, 12 };
+        static const uint64 BasisCounts[] = { 1, 2, 3, 4, 9, 4, 6, 5, 6, 9, 12 };
         StaticAssert_(ArraySize_(BasisCounts) == uint64(BakeModes::NumValues));
         Assert_(BasisCounts[bakeMode] <= MaxBasisCount);
         return BasisCounts[bakeMode];
@@ -627,7 +628,7 @@ namespace AppSettings
 
     inline bool SupportsProgressiveIntegration(BakeModes bakeMode, SolveModes solveMode)
     {
-        if(SGCount(bakeMode) > 0 && (solveMode == SolveModes::SVD || solveMode == SolveModes::NNLS))
+        if((bakeMode == BakeModes::Directional) || (SGCount(bakeMode) > 0 && (solveMode == SolveModes::SVD || solveMode == SolveModes::NNLS)))
             return false;
         else
             return true;

--- a/BakingLab/AppSettings.hlsl
+++ b/BakingLab/AppSettings.hlsl
@@ -180,15 +180,16 @@ static const int SampleModes_UniformGrid = 3;
 static const int SampleModes_CMJ = 4;
 
 static const int BakeModes_Diffuse = 0;
-static const int BakeModes_HL2 = 1;
-static const int BakeModes_SH4 = 2;
-static const int BakeModes_SH9 = 3;
-static const int BakeModes_H4 = 4;
-static const int BakeModes_H6 = 5;
-static const int BakeModes_SG5 = 6;
-static const int BakeModes_SG6 = 7;
-static const int BakeModes_SG9 = 8;
-static const int BakeModes_SG12 = 9;
+static const int BakeModes_Directional = 1;
+static const int BakeModes_HL2 = 2;
+static const int BakeModes_SH4 = 3;
+static const int BakeModes_SH9 = 4;
+static const int BakeModes_H4 = 5;
+static const int BakeModes_H6 = 6;
+static const int BakeModes_SG5 = 7;
+static const int BakeModes_SG6 = 8;
+static const int BakeModes_SG9 = 9;
+static const int BakeModes_SG12 = 10;
 
 static const int SolveModes_Projection = 0;
 static const int SolveModes_SVD = 1;

--- a/BakingLab/BakeDataVisualizer.hlsl
+++ b/BakingLab/BakeDataVisualizer.hlsl
@@ -130,6 +130,20 @@ float4 PS(in PSInput input) : SV_Target0
             output += saturate(dot(normalTS, BasisDirs[i])) * lightMap * InvPi;
         }
     }
+	else if (BakeMode == BakeModes_Directional)
+	{
+        float3 lightMapColor = BakedLightingMap.SampleLevel(LinearSampler, float3(uv, 0), 0.0f).xyz * Pi;
+        float4 lightmapDirection = BakedLightingMap.SampleLevel(LinearSampler, float3(uv, 1), 0.0f).xyzw;
+
+        float rebalancingCoefficient = max(lightmapDirection.w, 0.0001);
+
+        lightmapDirection = lightmapDirection * 2.0f - 1.0f;
+
+        float4 tau = float4(normalize(normalWS), 1.0f) * 0.5f;
+        float halfLambert = dot(tau, float4(lightmapDirection.xyz, 1.0f));
+
+        output = lightMapColor * halfLambert / rebalancingCoefficient;
+	}
     else if(BakeMode == BakeModes_SH4)
     {
         SH4Color shRadiance;

--- a/BakingLab/Mesh.hlsl
+++ b/BakingLab/Mesh.hlsl
@@ -645,6 +645,20 @@ PSOutput PS(in PSInput input)
                 indirectIrradiance += saturate(dot(normalTS, BasisDirs[i])) * lightMap;
             }
         }
+		else if (BakeMode == BakeModes_Directional)
+		{
+			float3 lightMapColor = BakedLightingMap.SampleLevel(LinearSampler, float3(input.LightMapUV, 0), 0.0f).xyz * Pi;
+			float4 lightmapDirection = BakedLightingMap.SampleLevel(LinearSampler, float3(input.LightMapUV, 1), 0.0f).xyzw;
+
+			float rebalancingCoefficient = max(lightmapDirection.w, 0.0001);
+
+			lightmapDirection = lightmapDirection * 2.0f - 1.0f;
+
+			float4 tau = float4(normalize(normalWS), 1.0f) * 0.5f;
+			float halfLambert = dot(tau, float4(lightmapDirection.xyz, 1.0f));
+
+			indirectIrradiance = lightMapColor * halfLambert / rebalancingCoefficient;
+		}
         else if(BakeMode == BakeModes_SH4)
         {
             SH4Color shRadiance;

--- a/SampleFramework11/v1.02/SF11_Math.cpp
+++ b/SampleFramework11/v1.02/SF11_Math.cpp
@@ -467,6 +467,15 @@ Float3 Float3::Perpendicular(const Float3& vec)
     return Float3::Normalize(perp);
 }
 
+Float3 Float3::Max(const Float3& a, const Float3& b)
+{
+	Float3 retVal;
+	retVal.x = SampleFramework11::Max(a.x, b.x);
+	retVal.y = SampleFramework11::Max(a.y, b.y);
+	retVal.z = SampleFramework11::Max(a.z, b.z);
+	return retVal;
+}
+
 float Float3::Distance(const Float3& a, const Float3& b)
 {
     XMVECTOR x = a.ToSIMD();
@@ -636,6 +645,11 @@ Float2 Float4::To2D() const
     return Float2(x, y);
 }
 
+float Float4::Dot(const Float4& a, const Float4& b)
+{
+	return XMVectorGetX(XMVector4Dot(a.ToSIMD(), b.ToSIMD()));
+}
+
 Float4 Float4::Clamp(const Float4& val, const Float4& min, const Float4& max)
 {
     Float4 retVal;
@@ -644,6 +658,13 @@ Float4 Float4::Clamp(const Float4& val, const Float4& min, const Float4& max)
     retVal.z = SampleFramework11::Clamp(val.z, min.z, max.z);
     retVal.w = SampleFramework11::Clamp(val.w, min.w, max.w);
     return retVal;
+}
+
+Float4 Float4::Normalize(const Float4& a)
+{
+	Float4 result;
+	XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(&result), XMVector4Normalize(a.ToSIMD()));
+	return result;
 }
 
 Float4 Float4::Transform(const Float4& v, const Float4x4& m)

--- a/SampleFramework11/v1.02/SF11_Math.h
+++ b/SampleFramework11/v1.02/SF11_Math.h
@@ -116,6 +116,7 @@ struct Float3
     static Float3 Transform(const Float3& v, const Quaternion& q);
     static Float3 Clamp(const Float3& val, const Float3& min, const Float3& max);
     static Float3 Perpendicular(const Float3& v);
+	static Float3 Max(const Float3& a, const Float3& b);
     static float Distance(const Float3& a, const Float3& b);
     static float Length(const Float3& v);
 };
@@ -155,7 +156,9 @@ struct Float4
     Float3 To3D() const;
     Float2 To2D() const;
 
+	static float Dot(const Float4& a, const Float4& b);
     static Float4 Clamp(const Float4& val, const Float4& min, const Float4& max);
+	static Float4 Float4::Normalize(const Float4& a);
     static Float4 Transform(const Float4& v, const Float4x4& m);
 };
 


### PR DESCRIPTION
It stores 3 floats for color, 3 for lighting main direction information,
and 1 float to ensure that the directional term evaluates to 1 when the
surface normal aligns with normal used when baking.

NOTE: A directional map can be encoded per RGB channel which puts the
memory cost at the cost of L1 SH but at a worse quality. This
implementation with a single directional map is provided as a cheap
alternative at the expense of quality.

Reference: https://static.docs.arm.com/100837/0308/enlighten_3-08_sdk_documentation__100837_0308_00_en.pdf