### PR TITLE
Add option to bake the direct contribution of the sun.

### DIFF
--- a/BakingLab/AppSettings.cpp
+++ b/BakingLab/AppSettings.cpp
@@ -196,6 +196,7 @@ namespace AppSettings
 {
     BoolSetting EnableSun;
     BoolSetting SunAreaLightApproximation;
+    BoolSetting BakeDirectSunLight;
     ColorSetting SunTintColor;
     FloatSetting SunIntensityScale;
     FloatSetting SunSize;
@@ -310,6 +311,9 @@ namespace AppSettings
 
         SunAreaLightApproximation.Initialize(tweakBar, "SunAreaLightApproximation", "Sun Light", "Sun Area Light Approximation", "Controls whether the sun is treated as a disc area light in the real-time shader", true);
         Settings.AddSetting(&SunAreaLightApproximation);
+
+        BakeDirectSunLight.Initialize(tweakBar, "BakeDirectSunLight", "Sun Light", "Bake Direct Sun Light", "Bakes the direct contribution from the sun light into the light map", false);
+        Settings.AddSetting(&BakeDirectSunLight);
 
         SunTintColor.Initialize(tweakBar, "SunTintColor", "Sun Light", "Sun Tint Color", "The color of the sun", Float3(1.0000f, 1.0000f, 1.0000f), false, -340282300000000000000000000000000000000.0000f, 340282300000000000000000000000000000000.0000f, 0.0100f, ColorUnit::None);
         Settings.AddSetting(&SunTintColor);
@@ -673,6 +677,7 @@ namespace AppSettings
     {
         CBuffer.Data.EnableSun = EnableSun;
         CBuffer.Data.SunAreaLightApproximation = SunAreaLightApproximation;
+        CBuffer.Data.BakeDirectSunLight = BakeDirectSunLight;
         CBuffer.Data.SunTintColor = SunTintColor;
         CBuffer.Data.SunIntensityScale = SunIntensityScale;
         CBuffer.Data.SunSize = SunSize;

--- a/BakingLab/AppSettings.cs
+++ b/BakingLab/AppSettings.cs
@@ -346,6 +346,9 @@ public class Settings
         [HelpText("Controls whether the sun is treated as a disc area light in the real-time shader")]
         bool SunAreaLightApproximation = true;
 
+        [HelpText("Bakes the direct contribution from the sun light into the light map")]
+        bool BakeDirectSunLight = false;
+
         [HelpText("The color of the sun")]
         Color SunTintColor = new Color(1.0f, 1.0f, 1.0f, 1.0f);
 

--- a/BakingLab/AppSettings.h
+++ b/BakingLab/AppSettings.h
@@ -278,6 +278,7 @@ namespace AppSettings
 
     extern BoolSetting EnableSun;
     extern BoolSetting SunAreaLightApproximation;
+    extern BoolSetting BakeDirectSunLight;
     extern ColorSetting SunTintColor;
     extern FloatSetting SunIntensityScale;
     extern FloatSetting SunSize;
@@ -385,6 +386,7 @@ namespace AppSettings
     {
         bool32 EnableSun;
         bool32 SunAreaLightApproximation;
+        bool32 BakeDirectSunLight;
         Float4Align Float3 SunTintColor;
         float SunIntensityScale;
         float SunSize;

--- a/BakingLab/AppSettings.hlsl
+++ b/BakingLab/AppSettings.hlsl
@@ -2,6 +2,7 @@ cbuffer AppSettings : register(b7)
 {
     bool EnableSun;
     bool SunAreaLightApproximation;
+    bool BakeDirectSunLight;
     float3 SunTintColor;
     float SunIntensityScale;
     float SunSize;

--- a/BakingLab/BakingLab.cpp
+++ b/BakingLab/BakingLab.cpp
@@ -61,6 +61,7 @@ StaticAssert_(ArraySize_(SceneAlbedoScales) >= uint64(Scenes::NumValues));
 static Setting* LightSettings[] =
 {
     &AppSettings::EnableSun,
+    &AppSettings::BakeDirectSunLight,
     &AppSettings::SunTintColor,
     &AppSettings::SunIntensityScale,
     &AppSettings::SunSize,

--- a/BakingLab/Mesh.hlsl
+++ b/BakingLab/Mesh.hlsl
@@ -580,7 +580,7 @@ PSOutput PS(in PSInput input)
     float3 lighting = 0.0f;
     float3 irradiance = 0.0f;
 
-    if(EnableDirectLighting && EnableSun)
+    if(EnableDirectLighting && EnableSun && !BakeDirectSunLight)
     {
         float3 sunIrradiance = 0.0f;
         float3 sunShadowVisibility = SunShadowVisibility(positionWS, depthVS);

--- a/BakingLab/MeshBaker.cpp
+++ b/BakingLab/MeshBaker.cpp
@@ -668,6 +668,14 @@ template<typename TBaker> static bool BakeDriver(BakeThreadContext& context, TBa
                     float illuminance = 0.0f;
                     bool hitSky = false;
                     sampleResult = PathTrace(params, random, illuminance, hitSky);
+
+                    if(AppSettings::BakeDirectSunLight)
+                    {
+                        Float3 sunLightIrradiance;
+                        sampleResult += SampleSunLight(bakePoint.Position, bakePoint.Normal, context.SceneBVH->Scene,
+                            1.0f, 0.0f, false, 0.0f, 1.0f, sampleSet.Lens().x,
+                            sampleSet.Lens().y, sunLightIrradiance);
+                    }
                 }
 
                 // Account for equally distributing our samples among the area light and the rest of the environment
@@ -745,6 +753,14 @@ template<typename TBaker> static bool BakeDriver(BakeThreadContext& context, TBa
                 float illuminance = 0.0f;
                 bool hitSky = false;
                 sampleResult = PathTrace(params, random, illuminance, hitSky);
+
+                if(AppSettings::BakeDirectSunLight)
+                {
+                    Float3 sunLightIrradiance;
+                    sampleResult += SampleSunLight(bakePoint.Position, bakePoint.Normal, context.SceneBVH->Scene,
+                        1.0f, 0.0f, false, 0.0f, 1.0f, sampleSet.Lens().x,
+                        sampleSet.Lens().y, sunLightIrradiance);
+                }
             }
 
             // Account for equally distributing our samples among the area light and the rest of the environment
@@ -1664,7 +1680,8 @@ MeshBakerStatus MeshBaker::Update(const Camera& camera, uint32 screenWidth, uint
         || AppSettings::SunTintColor.Changed() || AppSettings::SunIntensityScale.Changed()
         || AppSettings::SunSize.Changed() || AppSettings::NormalizeSunIntensity.Changed()
         || AppSettings::DiffuseAlbedoScale.Changed() || AppSettings::EnableAlbedoMaps.Changed()
-        || AppSettings::EnableAreaLightShadows.Changed() || AppSettings::MetallicOffset.Changed())
+        || AppSettings::EnableAreaLightShadows.Changed() || AppSettings::MetallicOffset.Changed()
+        || AppSettings::BakeDirectSunLight.Changed() || AppSettings::BakeDirectAreaLight.Changed())
     {
         InterlockedIncrement64(&renderTag);
         InterlockedIncrement64(&bakeTag);
@@ -1673,9 +1690,9 @@ MeshBakerStatus MeshBaker::Update(const Camera& camera, uint32 screenWidth, uint
     }
 
     // Change checks for baking only
-    if(AppSettings::BakeDirectAreaLight.Changed() || AppSettings::BakeRussianRouletteDepth.Changed()
-       || AppSettings::BakeRussianRouletteProbability.Changed() || AppSettings::MaxBakePathLength.Changed()
-       || AppSettings::SolveMode.Changed())
+    if(AppSettings::BakeDirectSunLight.Changed() || AppSettings::BakeDirectAreaLight.Changed()
+        || AppSettings::BakeRussianRouletteDepth.Changed() || AppSettings::BakeRussianRouletteProbability.Changed()
+        || AppSettings::MaxBakePathLength.Changed() || AppSettings::SolveMode.Changed())
     {
         InterlockedIncrement64(&bakeTag);
         currBakeBatch = 0;

--- a/BakingLab/PathTracer.h
+++ b/BakingLab/PathTracer.h
@@ -194,6 +194,11 @@ Float3 SampleAreaLight(const Float3& position, const Float3& normal, RTCScene sc
                        bool includeSpecular, Float3 specAlbedo, float roughness,
                        float u1, float u2, Float3& irradiance, Float3& sampleDir);
 
+Float3 SampleSunLight(const Float3& position, const Float3& normal, RTCScene scene,
+                      const Float3& diffuseAlbedo, const Float3& cameraPos,
+                      bool includeSpecular, Float3 specAlbedo, float roughness,
+                      float u1, float u2, Float3& irradiance);
+
 // Options for path tracing
 struct PathTracerParams
 {


### PR DESCRIPTION
Add the option to bake the direct contribution of the sun to better explain why it isn't good to bake the direct contribution of lights.

Baked sun on SH1 | Analytical sun
------------ | -------------
![image](https://user-images.githubusercontent.com/894286/76188841-64a8e380-6196-11ea-8ed4-0325b808949f.png) | ![image](https://user-images.githubusercontent.com/894286/76188854-6bcff180-6196-11ea-89f3-f549fdb804c2.png)
